### PR TITLE
認可処理

### DIFF
--- a/src/main/java/oit/is/team0804/kaizi/lec04/security/Sample3AuthConfiguration.java
+++ b/src/main/java/oit/is/team0804/kaizi/lec04/security/Sample3AuthConfiguration.java
@@ -13,6 +13,30 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @Configuration
 @EnableWebSecurity
 public class Sample3AuthConfiguration {
+  /**
+   * 認可処理に関する設定（認証されたユーザがどこにアクセスできるか）
+   *
+   * @param http
+   * @return
+   * @throws Exception
+   */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.formLogin(login -> login
+        .permitAll())
+        .logout(logout -> logout
+            .logoutUrl("/logout")
+            .logoutSuccessUrl("/")) // ログアウト後に / にリダイレクト
+        .authorizeHttpRequests(authz -> authz
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/sample4/**"))
+            .authenticated() // /sample4/以下は認証済みであること
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/**"))
+            .permitAll())// 上記以外は全員アクセス可能
+        .headers(headers -> headers
+            .frameOptions(frameOptions -> frameOptions
+                .sameOrigin()));
+    return http.build();
+  }
 
   /**
    * 認証処理に関する設定（誰がどのようなロールでログインできるか）


### PR DESCRIPTION
以下の3つの認可に伴う処理をSample3AuthConfiguration.javaに実装
・SpringSecurityのフォームを利用する
・/sample4 で始まるURLへのアクセス時にのみ認証を必要とする (例：http://localhost:8080/sample4/hoge)
・ログアウト時にはトップページ (http://localhost:8080/)に戻る
